### PR TITLE
Add payer handler architecture

### DIFF
--- a/src/tic_mrf_scraper/payers/__init__.py
+++ b/src/tic_mrf_scraper/payers/__init__.py
@@ -1,0 +1,32 @@
+from typing import Dict, Any, List, Type
+
+from ..fetch.blobs import list_mrf_blobs_enhanced
+
+
+class PayerHandler:
+    """Base class for payer specific logic."""
+
+    def list_mrf_files(self, index_url: str) -> List[Dict[str, Any]]:
+        """Return list of MRF metadata dictionaries for an index."""
+        return list_mrf_blobs_enhanced(index_url)
+
+    def parse_in_network(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Hook to massage an in_network record before parsing."""
+        return [record]
+
+
+_handler_registry: Dict[str, Type[PayerHandler]] = {}
+
+
+def register_handler(name: str):
+    """Decorator to register a handler for a payer."""
+    def wrapper(cls: Type[PayerHandler]):
+        _handler_registry[name.lower()] = cls
+        return cls
+    return wrapper
+
+
+def get_handler(name: str) -> PayerHandler:
+    """Return handler instance for payer name."""
+    cls = _handler_registry.get(name.lower(), PayerHandler)
+    return cls()

--- a/src/tic_mrf_scraper/payers/centene.py
+++ b/src/tic_mrf_scraper/payers/centene.py
@@ -1,0 +1,22 @@
+from typing import Dict, Any, List
+
+from . import PayerHandler, register_handler
+
+
+@register_handler("centene")
+@register_handler("centene_fidelis")
+class CenteneHandler(PayerHandler):
+    """Handler for Centene-family payers."""
+
+    def parse_in_network(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        # Centene sometimes places provider info directly under provider_groups
+        if "negotiated_rates" in record:
+            for group in record.get("negotiated_rates", []):
+                normalized = []
+                for pg in group.get("provider_groups", []):
+                    if "npi" in pg:
+                        normalized.append({"providers": [pg]})
+                    else:
+                        normalized.append(pg)
+                group["provider_groups"] = normalized
+        return [record]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+from tic_mrf_scraper.payers import PayerHandler, register_handler, get_handler
+from tic_mrf_scraper.stream.parser import stream_parse_enhanced
+import gzip, json
+from io import BytesIO
+
+
+def make_gzipped(data):
+    bio = BytesIO()
+    with gzip.GzipFile(fileobj=bio, mode="w") as gz:
+        gz.write(json.dumps(data).encode())
+    bio.seek(0)
+    return bio.getvalue()
+
+
+def test_handler_registry_lookup():
+    handler = get_handler("centene")
+    assert isinstance(handler, PayerHandler)
+
+
+def test_parse_in_network_hook():
+    class Dummy(PayerHandler):
+        def parse_in_network(self, record):
+            record["extra"] = True
+            return [record]
+
+    dummy = Dummy()
+
+    mrf = {
+        "in_network": [
+            {
+                "billing_code": "99213",
+                "negotiated_rates": [
+                    {
+                        "provider_groups": [{"providers": [{"npi": "1"}]}],
+                        "negotiated_prices": [{"negotiated_rate": 10, "service_code": ["11"]}]
+                    }
+                ]
+            }
+        ]
+    }
+
+    with patch("tic_mrf_scraper.stream.parser.fetch_url", return_value=make_gzipped(mrf)):
+        records = list(stream_parse_enhanced("mock", "TEST", handler=dummy))
+
+    assert records[0]["extra"] is True


### PR DESCRIPTION
## Summary
- support payer-specific logic via `PayerHandler`
- implement Centene handler example
- update parser and pipelines to use handlers
- provide config loader helper
- extend tests for handler registry and adjust main tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684b93143b988321850d9e9acacfa0ad