### PR TITLE
Add format identifier helpers

### DIFF
--- a/src/tic_mrf_scraper/utils/__init__.py
+++ b/src/tic_mrf_scraper/utils/__init__.py
@@ -1,0 +1,9 @@
+"""Utility subpackage."""
+
+from .format_identifier import detect_compression, identify_index, identify_in_network
+
+__all__ = [
+    "detect_compression",
+    "identify_index",
+    "identify_in_network",
+]

--- a/src/tic_mrf_scraper/utils/format_identifier.py
+++ b/src/tic_mrf_scraper/utils/format_identifier.py
@@ -1,0 +1,35 @@
+"""Utility helpers for detecting MRF formats and structures."""
+
+from typing import Dict, Any
+from urllib.parse import urlparse
+
+from ..transform.normalize import validate_mrf_structure
+
+
+def detect_compression(url: str) -> str:
+    """Detect the file compression type based on URL extension."""
+    path = urlparse(url).path.lower()
+    if path.endswith(".json.gz"):
+        return "json.gz"
+    if path.endswith(".json"):
+        return "json"
+    if path.endswith(".tar.gz"):
+        return "tar.gz"
+    if path.endswith(".gz"):
+        return "gz"
+    if path.endswith(".zip"):
+        return "zip"
+    if "." in path:
+        return path.rsplit(".", 1)[-1]
+    return "unknown"
+
+
+def identify_index(url: str) -> Dict[str, Any]:
+    """Analyze an index URL and return structure information."""
+    from ..fetch.blobs import analyze_index_structure
+    return analyze_index_structure(url)
+
+
+def identify_in_network(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate an in-network MRF JSON structure."""
+    return validate_mrf_structure(data)

--- a/tests/test_format_identifier.py
+++ b/tests/test_format_identifier.py
@@ -1,0 +1,23 @@
+from tic_mrf_scraper.utils.format_identifier import (
+    detect_compression,
+    identify_in_network,
+)
+
+def test_detect_compression():
+    assert detect_compression('http://example.com/file.json') == 'json'
+    assert detect_compression('http://example.com/file.json.gz') == 'json.gz'
+
+def test_identify_in_network_structure():
+    sample = {
+        'in_network': [
+            {
+                'billing_code': '12345',
+                'negotiated_rates': []
+            }
+        ]
+    }
+    report = identify_in_network(sample)
+    assert report['is_valid_tic_mrf'] is True
+    assert report['structure_type'] == 'in_network_rates'
+    assert report['in_network_count'] == 1
+


### PR DESCRIPTION
## Summary
- add helpers for detecting compression and identifying MRF formats
- expose helper functions via utils package
- add unit tests for compression and structure identification

## Testing
- `PYTHONPATH=src pytest -q tests/test_format_identifier.py`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684b9b7899c883219319b36f35223220