### PR TITLE
Add payer handler skeleton and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ my_payer = "tic_mrf_scraper.handlers.my_handler:MyHandler"
 ```
 
 3. Reinstall the package with `pip install -e .` to load the plugin.
+
+### Built-in payer modules
+
+Handlers included with the project live in `src/tic_mrf_scraper/payers`. The file name of the module
+is used as a **format identifier**. This identifier appears in `production_config.yaml` under
+`payer_endpoints` and determines which handler processes an index. Each module should declare a
+subclass of `PayerHandler` decorated with `@register_handler("<identifier>")`. Override
+`parse_in_network` whenever the payer's MRF format deviates from the default structure. See
+`src/tic_mrf_scraper/payers/example.py` for a minimal template.
 ## Running Tests
 
 1. Install development dependencies with `pip install -r requirements.txt` (or `poetry install`).

--- a/src/tic_mrf_scraper/payers/__init__.py
+++ b/src/tic_mrf_scraper/payers/__init__.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any, List, Type
+import warnings
 
 from ..fetch.blobs import list_mrf_blobs_enhanced
 
@@ -11,7 +12,12 @@ class PayerHandler:
         return list_mrf_blobs_enhanced(index_url)
 
     def parse_in_network(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Hook to massage an in_network record before parsing."""
+        """Modify one ``in_network`` item before normalization.
+
+        Subclasses should override this method when a payer's MRF deviates from
+        the standard structure. The method must return a list of records to be
+        passed into the normal parser.
+        """
         return [record]
 
 
@@ -21,6 +27,12 @@ _handler_registry: Dict[str, Type[PayerHandler]] = {}
 def register_handler(name: str):
     """Decorator to register a handler for a payer."""
     def wrapper(cls: Type[PayerHandler]):
+        if cls.parse_in_network is PayerHandler.parse_in_network:
+            warnings.warn(
+                f"{cls.__name__} does not override parse_in_network; "
+                "copy the base implementation or provide custom logic if needed",
+                UserWarning,
+            )
         _handler_registry[name.lower()] = cls
         return cls
     return wrapper

--- a/src/tic_mrf_scraper/payers/example.py
+++ b/src/tic_mrf_scraper/payers/example.py
@@ -1,0 +1,12 @@
+from typing import Dict, Any, List
+
+from . import PayerHandler, register_handler
+
+
+@register_handler("example")
+class ExampleHandler(PayerHandler):
+    """Skeleton payer handler for custom formats."""
+
+    def parse_in_network(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Modify an ``in_network`` item if needed and return one or more records."""
+        return super().parse_in_network(record)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,5 +1,10 @@
 from unittest.mock import MagicMock, patch
-from tic_mrf_scraper.payers import PayerHandler, register_handler, get_handler
+from tic_mrf_scraper.payers import (
+    PayerHandler,
+    register_handler,
+    get_handler,
+    _handler_registry,
+)
 from tic_mrf_scraper.stream.parser import stream_parse_enhanced
 import gzip, json
 from io import BytesIO
@@ -44,3 +49,8 @@ def test_parse_in_network_hook():
         records = list(stream_parse_enhanced("mock", "TEST", handler=dummy))
 
     assert records[0]["extra"] is True
+
+
+def test_registered_handlers_have_parse_method():
+    for name, cls in _handler_registry.items():
+        assert callable(getattr(cls, "parse_in_network", None))


### PR DESCRIPTION
## Summary
- warn if new handlers don't override `parse_in_network`
- add example payer handler for quick extension
- document built-in payer modules and format identifier
- test that each registered handler has `parse_in_network`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684b9b8acf288321a754100d46f93ff7