### PR TITLE
Cache CPT whitelist set at pipeline init

### DIFF
--- a/production_etl_pipeline.py
+++ b/production_etl_pipeline.py
@@ -243,6 +243,7 @@ class ProductionETLPipeline:
     
     def __init__(self, config: ETLConfig):
         self.config = config
+        self.cpt_whitelist_set = set(config.cpt_whitelist)
         self.uuid_gen = UUIDGenerator()
         self.validator = DataQualityValidator()
         self.s3_client = boto3.client('s3') if config.s3_bucket else None
@@ -527,8 +528,8 @@ class ProductionETLPipeline:
                 
                 # Normalize and validate
                 normalized = normalize_tic_record(
-                    raw_record, 
-                    set(self.config.cpt_whitelist), 
+                    raw_record,
+                    self.cpt_whitelist_set,
                     payer_name
                 )
                 

--- a/production_etl_pipeline_quiet.py
+++ b/production_etl_pipeline_quiet.py
@@ -113,6 +113,7 @@ class ProductionETLPipelineQuiet:
     
     def __init__(self, config: Dict[str, Any], progress_file: str, verbosity: str = "progress"):
         self.config = config
+        self.cpt_whitelist_set = set(config['cpt_whitelist'])
         self.progress_tracker = ProgressTracker(progress_file, verbosity)
         self.s3_client = boto3.client('s3') if config.get('s3_bucket') else None
         
@@ -237,8 +238,8 @@ class ProductionETLPipelineQuiet:
             # Process record
             try:
                 normalized = normalize_tic_record(
-                    raw_record, 
-                    set(self.config['cpt_whitelist']), 
+                    raw_record,
+                    self.cpt_whitelist_set,
                     payer_name
                 )
                 


### PR DESCRIPTION
## Summary
- Cache CPT whitelist as a set during pipeline initialization
- Reuse cached set when normalizing records in both pipeline implementations

## Testing
- `PYTHONPATH=src pytest tests/test_normalize.py -q`
- `PYTHONPATH=src pytest tests/test_pipeline_limits.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688f76c366c08321b488c0565cf994ea