### PR TITLE
Use generators for MRF file discovery

### DIFF
--- a/src/tic_mrf_scraper/payers/__init__.py
+++ b/src/tic_mrf_scraper/payers/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Type
+from typing import Dict, Any, List, Type, Iterator
 import warnings
 
 from ..fetch.blobs import list_mrf_blobs_enhanced
@@ -7,8 +7,8 @@ from ..fetch.blobs import list_mrf_blobs_enhanced
 class PayerHandler:
     """Base class for payer specific logic."""
 
-    def list_mrf_files(self, index_url: str) -> List[Dict[str, Any]]:
-        """Return list of MRF metadata dictionaries for an index."""
+    def list_mrf_files(self, index_url: str) -> Iterator[Dict[str, Any]]:
+        """Yield MRF metadata dictionaries for an index."""
         return list_mrf_blobs_enhanced(index_url)
 
     def parse_in_network(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- stream MRF blob metadata instead of building large lists
- adjust PayerHandler and CLI to process files as they are yielded
- update ETL pipelines to iterate over MRF files without retaining all metadata

## Testing
- `python -m py_compile production_etl_pipeline.py production_etl_pipeline_quiet.py src/tic_mrf_scraper/__main__.py src/tic_mrf_scraper/fetch/blobs.py src/tic_mrf_scraper/payers/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_688f76c7a5b08321bb9fa501a811445c